### PR TITLE
fix: Improve GitHub link contrast and confirm logo path

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -33,6 +33,15 @@ header {
     color: #f8f9fa; // Lighter text for tagline
   }
 
+  p.view a {
+    color: #e9ecef; // Light gray for better contrast on primary background
+    text-decoration: underline;
+  }
+
+  p.view a:hover {
+    color: #fff; // White on hover
+  }
+
   img {
     max-width: 150px; // Adjust as needed
     margin-bottom: 10px;


### PR DESCRIPTION
- Updated CSS to ensure the 'View the Project on GitHub' link in the header has better contrast against the background.
- Verified that the logo path in _config.yml and its usage in the layout are correct. The broken logo link is due to the logo.png file not being present in assets/images/, which needs to be manually uploaded.